### PR TITLE
Add compatibility with material 1.1.0+ lib

### DIFF
--- a/FitChart/src/main/java/com/txusballesteros/widgets/FitChart.java
+++ b/FitChart/src/main/java/com/txusballesteros/widgets/FitChart.java
@@ -207,7 +207,7 @@ public class FitChart extends View {
                     .getColor(R.styleable.FitChart_valueStrokeColor, valueStrokeColor);
             backStrokeColor = attributes
                     .getColor(R.styleable.FitChart_backStrokeColor, backStrokeColor);
-            int attrAnimationMode = attributes.getInteger(R.styleable.FitChart_animationMode, ANIMATION_MODE_LINEAR);
+            int attrAnimationMode = attributes.getInteger(R.styleable.FitChart_animationMethod, ANIMATION_MODE_LINEAR);
             if (attrAnimationMode == ANIMATION_MODE_LINEAR) {
                 animationMode = AnimationMode.LINEAR;
             } else {

--- a/FitChart/src/main/res/values/attributes.xml
+++ b/FitChart/src/main/res/values/attributes.xml
@@ -28,7 +28,7 @@
         <attr name="strokeSize" format="dimension|reference" />
         <attr name="valueStrokeColor" format="color|reference" />
         <attr name="backStrokeColor" format="color|reference" />
-        <attr name="animationMode">
+        <attr name="animationMethod">
             <enum name="linear" value="0" />
             <enum name="overdraw" value="1" />
         </attr>


### PR DESCRIPTION
Google's material UI library contains an animationMode attr which causes gradle errors when building with this library.

https://stackoverflow.com/questions/60247942/is-anybody-else-getting-errors-when-upgrading-to-com-google-android-materialmat

https://github.com/txusballesteros/fit-chart/issues/18